### PR TITLE
Temporary fix for Vulkan shaders compilation

### DIFF
--- a/com.popcornfx.PopcornFXEditor.yaml
+++ b/com.popcornfx.PopcornFXEditor.yaml
@@ -70,5 +70,6 @@ modules:
       - type: script
         commands:
         - cd /app/pk-editor/bin
+        - export PATH=/app/pk-editor/Resources:$PATH
         - exec ./PK-Editor "$@"
         dest-filename: popcornfx-editor.sh


### PR DESCRIPTION
The path of glslangValidator is invalid in the editor preferences.
This will be fixed in the v2.21.2 of PopcornFX Editor but add it to path in the meantime.