### PR TITLE
Make OpenGL the default rendering API

### DIFF
--- a/com.popcornfx.PopcornFXEditor.yaml
+++ b/com.popcornfx.PopcornFXEditor.yaml
@@ -71,5 +71,5 @@ modules:
         commands:
         - cd /app/pk-editor/bin
         - export PATH=/app/pk-editor/Resources:$PATH
-        - exec ./PK-Editor "$@"
+        - exec ./PK-Editor -r OpenGL "$@"
         dest-filename: popcornfx-editor.sh


### PR DESCRIPTION
There are currently too much issues with Vulkan.
Force OpenGL to be the default api by command line argument for now.